### PR TITLE
CNAME file needs to carry through to gh-page branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
-    "deploy": "gatsby build --prefix-paths && gh-pages -d public"
+    "deploy": "gatsby build --prefix-paths && cp CNAME public/CNAME && gh-pages -d public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It seems like DNS configuration on Github's end went out of wack because the CNAME file doesn't get copied over into the public folder when building. Extended deploy command to do that